### PR TITLE
SurveyJS should not show "completed" message

### DIFF
--- a/src/survey_metadata.js
+++ b/src/survey_metadata.js
@@ -443,7 +443,8 @@ var surveyJSON = {
    "expression": "{earned_300_dollars} = 'n'"
   }
  ],
- "showTitle": false
+ "showTitle": false,
+ "showCompletedPage": false
 }
 
 export {surveyJSON};


### PR DESCRIPTION
Do not show the "Thank you for completing the survey!" message after the user is done with the survey.  Just show the eligibility results.