### PR TITLE
"let" is safer than "var" in JS

### DIFF
--- a/src/components/eligibilities_display_cfra_eligible_public_school_or_government_employee.js
+++ b/src/components/eligibilities_display_cfra_eligible_public_school_or_government_employee.js
@@ -7,11 +7,11 @@ import {Disclaimer} from './disclaimer.js';
 
 class EligibilityDisplayCFRAGovtEmployee extends React.Component {
   render() {
-    var birthdayInfo = '';
+    let birthdayInfo = '';
     if (this.props.birthday) {
       const birthdate = new Date(this.props.birthday);
       const today = new Date();
-      var age =Math.abs(Math.round((today.getTime() - birthdate.getTime()) / (1000* 60 * 60 * 24 * 365.25)));
+      let age =Math.abs(Math.round((today.getTime() - birthdate.getTime()) / (1000* 60 * 60 * 24 * 365.25)));
       birthdayInfo = 'You are ' + age + ' years old';
     }
     else {

--- a/src/eligibilities_display.js
+++ b/src/eligibilities_display.js
@@ -8,10 +8,10 @@ function Eligibility(info) {
   console.log("Rendering eligibility info", info);
   const result = RESULTS[info.eligibility];
   if (result.react) {
-    var label = <span className='attention' key='label'>{result.label}</span>
+    let label = <span className='attention' key='label'>{result.label}</span>
     let elementProps = { ...info.values };
     elementProps['key'] = 'eligibility'
-    var element = React.createElement(result.react, elementProps);
+    let element = React.createElement(result.react, elementProps);
     return [
       label,
       element

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import {getEligibilityMatch} from './eligibility_checker.js'
 import {EligibilitiesDisplay} from './eligibilities_display.js'
 
 
-var eligibilitiesDisplay = 0;
+let eligibilitiesDisplay = 0;
 
 function onSurveyComplete(results) {
   let eligibilityMatch = getEligibilityMatch(results.valuesHash);

--- a/src/survey_metadata.js
+++ b/src/survey_metadata.js
@@ -11,7 +11,7 @@ Once you have JSON you would like to use, replace the value
 of the "surveyJSON" variable with that value.  This file should
 look something like:
 
-  var surveyJSON = [YOUR JSON HERE]
+  let surveyJSON = [YOUR JSON HERE]
 
   export {surveyJSON};
 
@@ -20,7 +20,7 @@ eligible for which programs.  That information is stored in
 the eligibility_matrix.js file.
 */
 
-var surveyJSON = {
+let surveyJSON = {
  "title": "SimpleLeavePlanner",
  "pages": [
   {


### PR DESCRIPTION
Should use "let" instead of "var" syntax in Javascript- old habits die hard...